### PR TITLE
Use cogs:Jobs and integrate with Job controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,28 @@ The resulting triples are validated and converted to a submission for 'Loket voo
 ### Model
 
 #### Automatic submission task
-A resource describing the status and progress of the processing of an automatic submission.
+
+A resource describing the status and operation of the subtask of processing an automatic submission job.
 
 ##### Class
-`melding:AutomaticSubmissionTask`
+
+`task:Task`
 
 ##### Properties
-The model is specified in the [README of the automatic submission service](https://github.com/lblod/automatic-submission-service#model).
+
+The model is specified in the [README of the job-controller-service](https://github.com/lblod/job-controller-service#task).
+
 ___
+
 #### Automatic submission task statuses
-Once the import process starts, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/importing.
 
-On successful completion, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/ready-for-enrichment.
+Once the enrichment process starts, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
 
-On failure, the status is updated to http://lblod.data.gift/automatische-melding-statuses/failure.
+On successful completion, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/success. The resultsContainer is then linked to the inputContainer of the task, because no file has been created or modified, only triples in the database.
+
+On failure, the status is updated to http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error is written to the database and the error is linked to this failed task.
 ___
+
 #### Annotated RDFa/HTML document
 Local copy of the published submission in RDFa/HTML format as downloaded by the [download-url-service](https://github.com/lblod/download-url-service). This document is used as source to harvest triples from.
 

--- a/app.js
+++ b/app.js
@@ -124,15 +124,5 @@ function calculateAttachmentsToDownlad(triples, submittedDocument){
   return allAttachments;
 }
 
-/**
- * Returns whether the passed triple is a trigger for an import process
- *
- * @param Object triple Triple as received from the delta notifier
-*/
-function isTriggerTriple(triple) {
-  return triple.predicate.value == 'http://www.w3.org/ns/adms#status'
-    && triple.object.value == 'http://lblod.data.gift/file-download-statuses/success';
-}
-
 app.use(errorHandler);
 

--- a/app.js
+++ b/app.js
@@ -1,21 +1,14 @@
 import bodyParser from 'body-parser';
-import { flatten } from 'lodash';
 import { app, errorHandler } from 'mu';
 import { scheduleDownloadAttachment } from './lib/attachment-helpers';
-import {
-    getFileContent,
-    writeTtlFile
-} from './lib/file-helpers';
+import { loadFileData, writeTtlFile } from './lib/file-helpers';
 import RdfaExtractor from './lib/rdfa-extractor';
-import enrichSubmission, { enrichWithAttachmentInfo } from './lib/submission-enricher';
-import {
-    getTasks, TASK_FAILURE_STATUS, TASK_ONGOING_STATUS,
-    TASK_SUCCESS_STATUS, updateTaskStatus
-} from './lib/submission-task';
-
-import { isCentraalBestuurVanEredienstDocument } from './lib/utils';
-
+import { enrichSubmission, enrichWithAttachmentInfo } from './lib/submission-enricher';
+import { getFileUris, getSubmissionInfo } from './lib/submission-task';
+import * as env from './constants.js';
+import { saveError, isCentraalBestuurVanEredienstDocument } from './lib/utils';
 import { getAuthenticationConfigForSubmission, cleanCredentials } from './lib/credential-helpers';
+import { updateTaskStatus } from './lib/submission-task.js';
 
 app.use(bodyParser.json({ type: function(req) { return /^application\/json/.test(req.get('content-type')); } }));
 
@@ -24,70 +17,68 @@ app.get('/', function(req, res) {
 });
 
 app.post('/delta', async function(req, res, next) {
-  const remoteFiles = getRemoteFileUris(req.body);
-  if (!remoteFiles.length) {
-    console.log("Delta does not contain a new remote data object with status 'success'. Nothing should happen.");
-    return res.status(204).send();
-  }
+  //We can already send a 200 back. The delta-notifier does not care about the result, as long as the request is closed.
+  res.status(200).send().end();
 
   try {
-    const notStartedTasks = await getTasks(remoteFiles);
+    //Don't trust the delta-notifier, filter as best as possible. We just need the task that was created to get started.
+    const actualTaskUris = req.body
+      .map((changeset) => changeset.inserts)
+      .filter((inserts) => inserts.length > 0)
+      .flat()
+      .filter((insert) => insert.predicate.value === env.OPERATION_PREDICATE)
+      .filter((insert) => insert.object.value === env.IMPORT_OPERATION)
+      .map((insert) => insert.subject.value);
 
-    for (let { task, submission, documentUrl, submittedDocument, remoteFile } of notStartedTasks) {
-      await updateTaskStatus(task, TASK_ONGOING_STATUS);
-      importSubmission(task, submission, documentUrl, submittedDocument, remoteFile); // async processing of import
+    for (const taskUri of actualTaskUris) {
+      try {
+        await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
+        const fileUris = await getFileUris(taskUri);
+        for (const fileUri of fileUris) {
+          await importSubmission(fileUri);
+        }
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS);
+      }
+      catch (error) {
+        const message = `Something went wrong while importing for task ${taskUri}`;
+        console.error(`${message}\n`, error.message);
+        console.error(error);
+        const errorUri = await saveError({ message, detail: error.message, });
+        await updateTaskStatus(taskUri, env.TASK_FAILURE_STATUS, errorUri);
+      }
     }
-
-    return res.status(200).send({ data: notStartedTasks  });
-  } catch (e) {
-    console.log(`Something went wrong while handling deltas for remote data objects ${remoteFiles.join(`, `)}`);
-    console.log(e);
-    return next(e);
+  }
+  catch (error) {
+    const message = 'The task for importing a submission could not even be started or finished due to an unexpected problem.';
+    console.error(`${message}\n`, error.message);
+    console.error(error);
+    await saveError({ message, detail: error.message, });
   }
 });
 
-async function importSubmission(task, submission, documentUrl, submittedDocument, remoteFile) {
-  try {
-    const html = await getFileContent(remoteFile);
+async function importSubmission(fileUri) {
+  const { submission, documentUrl, submittedDocument, remoteDataObject } = await getSubmissionInfo(fileUri);
+  const html = await loadFileData(fileUri);
+  const rdfaExtractor = new RdfaExtractor(html, documentUrl);
+  const triples = rdfaExtractor.rdfa();
+  const enrichments = await enrichSubmission(submittedDocument, fileUri, remoteDataObject, triples, documentUrl);
+  rdfaExtractor.add(enrichments);
 
-    const rdfaExtractor = new RdfaExtractor(html, documentUrl);
-    const triples = rdfaExtractor.rdfa();
-    const enrichments = await enrichSubmission(submittedDocument, remoteFile, triples);
-    rdfaExtractor.add(enrichments);
+  const attachmentUrls = calculateAttachmentsToDownlad(triples, submittedDocument);
 
-    const attachmentUrls = calculateAttachmentsToDownlad(triples, submittedDocument);
-
-    if(attachmentUrls.length){
-      console.log(`Found attachments: ${attachmentUrls.join('\n')}`);
-      for(const attachmentUrl of attachmentUrls){
-        //Note: there is no clear message when attachment download failed.
-        const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl);
-        const enrichments = await enrichWithAttachmentInfo(submittedDocument, remoteDataObject, attachmentUrl);
-        rdfaExtractor.add(enrichments);
-      }
-    }
-
-    const ttl = rdfaExtractor.ttl();
-    const uri = await writeTtlFile(ttl, submittedDocument, remoteFile);
-    console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteFile}> to <${uri}>`);
-    await updateTaskStatus(task, TASK_SUCCESS_STATUS);
-  }
-  catch (e) {
-    console.log(`Something went wrong while importing the submission from task ${task}`);
-    console.log(e);
-    // TODO add reason of failure message on task
-    try {
-      await updateTaskStatus(task, TASK_FAILURE_STATUS);
-    } catch (e) {
-      console.log(`Failed to update state of task ${task} to failure state. Is the connection to the database broken?`);
+  if(attachmentUrls.length){
+    console.log(`Found attachments: ${attachmentUrls.join('\n')}`);
+    for(const attachmentUrl of attachmentUrls){
+      //Note: there is no clear message when attachment download failed.
+      const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl);
+      const enrichments = await enrichWithAttachmentInfo(submittedDocument, remoteDataObject, attachmentUrl);
+      rdfaExtractor.add(enrichments);
     }
   }
-  finally {
-    console.log('Removing credentials from submission if any');
-    const authenticationConfig = await getAuthenticationConfigForSubmission(submission);
-    if (authenticationConfig)
-      await cleanCredentials(authenticationConfig.authenticationConfiguration);
-  }
+
+  const ttl = rdfaExtractor.ttl();
+  const uri = await writeTtlFile(ttl, submittedDocument, remoteDataObject);
+  console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteDataObject}> to <${uri}>`);
 }
 
 function calculateAttachmentsToDownlad(triples, submittedDocument){
@@ -131,17 +122,6 @@ function calculateAttachmentsToDownlad(triples, submittedDocument){
 }
 
 /**
- * Returns the inserted succesfully downloaded remote file URIs
- * from the delta message. An empty array if there are none.
- *
- * @param Object delta Message as received from the delta notifier
-*/
-function getRemoteFileUris(delta) {
-  const inserts = flatten(delta.map(changeSet => changeSet.inserts));
-  return inserts.filter(isTriggerTriple).map(t => t.subject.value);
-}
-
-/**
  * Returns whether the passed triple is a trigger for an import process
  *
  * @param Object triple Triple as received from the delta notifier
@@ -152,3 +132,4 @@ function isTriggerTriple(triple) {
 }
 
 app.use(errorHandler);
+

--- a/app.js
+++ b/app.js
@@ -34,10 +34,12 @@ app.post('/delta', async function(req, res, next) {
       try {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         const fileUris = await getFileUris(taskUri);
+        const importedFileUris = [];
         for (const fileUri of fileUris) {
-          await importSubmission(fileUri);
+          const importedFileUri = await importSubmission(fileUri);
+          importedFileUris.push(importedFileUri);
         }
-        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS);
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS, undefined, importedFileUris);
       }
       catch (error) {
         const message = `Something went wrong while importing for task ${taskUri}`;
@@ -79,6 +81,7 @@ async function importSubmission(fileUri) {
   const ttl = rdfaExtractor.ttl();
   const uri = await writeTtlFile(ttl, submittedDocument, remoteDataObject);
   console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteDataObject}> to <${uri}>`);
+  return uri;
 }
 
 function calculateAttachmentsToDownlad(triples, submittedDocument){

--- a/constants.js
+++ b/constants.js
@@ -1,27 +1,51 @@
-export const PREFIXES = `
-  PREFIX meb:   <http://rdf.myexperiment.org/ontologies/base/>
-  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-  PREFIX pav:   <http://purl.org/pav/>
-  PREFIX dct:   <http://purl.org/dc/terms/>
-  PREFIX melding:   <http://lblod.data.gift/vocabularies/automatische-melding/>
-  PREFIX lblodBesluit:  <http://lblod.data.gift/vocabularies/besluit/>
-  PREFIX adms:  <http://www.w3.org/ns/adms#>
-  PREFIX muAccount:   <http://mu.semte.ch/vocabularies/account/>
-  PREFIX eli:   <http://data.europa.eu/eli/ontology#>
-  PREFIX org:   <http://www.w3.org/ns/org#>
-  PREFIX elod:  <http://linkedeconomy.org/ontology#>
-  PREFIX nie:   <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-  PREFIX prov:  <http://www.w3.org/ns/prov#>
-  PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
-  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-  PREFIX nfo:   <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX http: <http://www.w3.org/2011/http#>
-  PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
-  PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
-  PREFIX dgftOauth: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
-  PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
-`;
+const PREFIX_TABLE = {
+  meb:          'http://rdf.myexperiment.org/ontologies/base/',
+  xsd:          'http://www.w3.org/2001/XMLSchema#',
+  pav:          'http://purl.org/pav/',
+  dct:          'http://purl.org/dc/terms/',
+  melding:      'http://lblod.data.gift/vocabularies/automatische-melding/',
+  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+  adms:         'http://www.w3.org/ns/adms#',
+  muAccount:    'http://mu.semte.ch/vocabularies/account/',
+  eli:          'http://data.europa.eu/eli/ontology#',
+  org:          'http://www.w3.org/ns/org#',
+  elod:         'http://linkedeconomy.org/ontology#',
+  nie:          'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  prov:         'http://www.w3.org/ns/prov#',
+  mu:           'http://mu.semte.ch/vocabularies/core/',
+  foaf:         'http://xmlns.com/foaf/0.1/',
+  nfo:          'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  ext:          'http://mu.semte.ch/vocabularies/ext/',
+  http:         'http://www.w3.org/2011/http#',
+  rpioHttp:     'http://redpencil.data.gift/vocabularies/http/',
+  dgftSec:      'http://lblod.data.gift/vocabularies/security/',
+  dgftOauth:    'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
+  wotSec:       'https://www.w3.org/2019/wot/security#',
+  task:         'http://redpencil.data.gift/vocabularies/tasks/',
+};
+
+export const PREFIXES = (() => {
+  const all = [];
+  for (const key in PREFIX_TABLE)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+})();
+
+export function getPrefixes(collOfPrefixes) {
+  const all = [];
+  for (const key of collOfPrefixes)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+}
 
 export const BASIC_AUTH = 'https://www.w3.org/2019/wot/security#BasicSecurityScheme';
 export const OAUTH2 = 'https://www.w3.org/2019/wot/security#OAuth2SecurityScheme';
+
+export const TASK_ONGOING_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/busy';
+export const TASK_SUCCESS_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/success';
+export const TASK_FAILURE_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/failed';
+
+export const OPERATION_PREDICATE = 'http://redpencil.data.gift/vocabularies/tasks/operation';
+export const IMPORT_OPERATION = 'http://lblod.data.gift/id/jobs/concept/TaskOperation/import';
+
+export const CREATOR = 'http://lblod.data.gift/services/import-submission-service';

--- a/constants.js
+++ b/constants.js
@@ -33,13 +33,6 @@ export const PREFIXES = (() => {
   return all.join('\n');
 })();
 
-export function getPrefixes(collOfPrefixes) {
-  const all = [];
-  for (const key of collOfPrefixes)
-    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
-  return all.join('\n');
-}
-
 export const BASIC_AUTH = 'https://www.w3.org/2019/wot/security#BasicSecurityScheme';
 export const OAUTH2 = 'https://www.w3.org/2019/wot/security#OAuth2SecurityScheme';
 

--- a/constants.js
+++ b/constants.js
@@ -22,6 +22,7 @@ const PREFIX_TABLE = {
   dgftOauth:    'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
   wotSec:       'https://www.w3.org/2019/wot/security#',
   task:         'http://redpencil.data.gift/vocabularies/tasks/',
+  asj:          'http://data.lblod.info/id/automatic-submission-job/',
 };
 
 export const PREFIXES = (() => {

--- a/constants.js
+++ b/constants.js
@@ -1,8 +1,9 @@
-const PREFIX_TABLE = {
+export const PREFIX_TABLE = {
   meb:          'http://rdf.myexperiment.org/ontologies/base/',
   xsd:          'http://www.w3.org/2001/XMLSchema#',
   pav:          'http://purl.org/pav/',
   dct:          'http://purl.org/dc/terms/',
+  dbpedia:      'http://dbpedia.org/ontology/',
   melding:      'http://lblod.data.gift/vocabularies/automatische-melding/',
   lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
   adms:         'http://www.w3.org/ns/adms#',

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -2,31 +2,6 @@ import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
 import { sparqlEscapeDateTime, sparqlEscapeInt, sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
 
-/**
- * Returns the content of the cached file for the given remote file
- *
- * @param string remoteFileUri URI of the remote file
-*/
-export async function getFileContent(remoteFileUri) {
-  const q = `
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-
-    SELECT ?file
-    WHERE {
-      ?file nie:dataSource ${sparqlEscapeUri(remoteFileUri)} .
-    } LIMIT 1
-  `;
-
-  const result = await query(q);
-  if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['file'].value;
-    return await loadFileData(file);
-  }
-  else {
-    return null;
-  }
-}
-
 export async function loadFileData(fileUri){
   console.log(`Getting contents of file ${fileUri}`);
   const path = fileUri.replace('share://', '/share/');

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -38,7 +38,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
     const fileSize = stats.size;
 
     await update(`
-      ${env.getPrefixes(['xsd', 'nfo', 'nie', 'mu', 'dct', 'dbpedia', 'asj'])}
+      ${env.PREFIXES}
       INSERT {
         GRAPH ?g {
           ${sparqlEscapeUri(physicalUri)}

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -1,6 +1,7 @@
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
 import { sparqlEscapeDateTime, sparqlEscapeInt, sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
+import * as env from '../constants.js';
 
 export async function loadFileData(fileUri){
   console.log(`Getting contents of file ${fileUri}`);
@@ -17,16 +18,18 @@ export async function loadFileData(fileUri){
  * @param string remoteFile URI of the remote file to relate the new TTL file to
 */
 export async function writeTtlFile(content, submittedDocument, remoteFile) {
-  const id = uuid();
-  const filename = `${id}.ttl`;
+  const physicalId = uuid();
+  const logicalId = uuid();
+  const filename = `${physicalId}.ttl`;
   const path = `/share/submissions/${filename}`;
-  const uri = path.replace('/share/', 'share://');
-  const now = new Date();
+  const physicalUri = path.replace('/share/', 'share://');
+  const logicalUri = env.PREFIX_TABLE.asj.concat(logicalId);
+  const nowSparql = sparqlEscapeDateTime(new Date());
 
   try {
     await fs.writeFile(path, content, 'utf-8');
   } catch (e) {
-    console.log(`Failed to write TTL to file <${uri}>.`);
+    console.log(`Failed to write TTL to file <${path}>.`);
     throw e;
   }
 
@@ -35,37 +38,44 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
     const fileSize = stats.size;
 
     await update(`
-      PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-
+      ${env.getPrefixes(['xsd', 'nfo', 'nie', 'mu', 'dct', 'dbpedia', 'asj'])}
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} a nfo:FileDataObject;
-                                  nie:dataSource ?localFile ;
-                                  mu:uuid ${sparqlEscapeString(id)};
-                                  nfo:fileName ${sparqlEscapeString(filename)} ;
-                                  dct:creator <http://lblod.data.gift/services/import-submission-service>;
-                                  dct:created ${sparqlEscapeDateTime(now)};
-                                  dct:modified ${sparqlEscapeDateTime(now)};
-                                  dct:format "text/turtle";
-                                  nfo:fileSize ${sparqlEscapeInt(fileSize)};
-                                  dbpedia:fileExtension "ttl" .
-          ${sparqlEscapeUri(submittedDocument)} dct:source ${sparqlEscapeUri(uri)} .
-        }
-      } WHERE {
-        GRAPH ?g {
-          ?localFile nie:dataSource ${sparqlEscapeUri(remoteFile)} .
+          ${sparqlEscapeUri(physicalUri)}
+            a nfo:FileDataObject;
+            nie:dataSource asj:${logicalId} ;
+            mu:uuid ${sparqlEscapeString(physicalId)};
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" .
+
+          asj:${logicalId}
+            a nfo:FileDataObject;
+            mu:uuid ${sparqlEscapeString(logicalId)} ;
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" .
+            
+          ${sparqlEscapeUri(submittedDocument)} dct:source asj:${logicalId} .
         }
       }
-`);
+      WHERE {
+        GRAPH ?g {
+          ${sparqlEscapeUri(remoteFile)} a nfo:FileDataObject .
+        }
+      }`);
 
   } catch (e) {
-    console.log(`Failed to write TTL resource <${uri}> to triplestore.`);
+    console.log(`Failed to write TTL resource <${physicalUri}> to triplestore.`);
     throw e;
   }
-
-  return uri;
+  return logicalUri;
 }

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -56,6 +56,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
           asj:${logicalId}
             a nfo:FileDataObject;
             mu:uuid ${sparqlEscapeString(logicalId)} ;
+            dct:type <http://data.lblod.gift/concepts/harvested-data> ;
             nfo:fileName ${sparqlEscapeString(filename)} ;
             dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
             dct:created ${nowSparql} ;

--- a/lib/submission-enricher.js
+++ b/lib/submission-enricher.js
@@ -8,7 +8,7 @@ import Triple from './triple';
  * Enrich the harvested triples dataset with derived knowledge
  * based on the current harvested triples and the data in the triplestore.
  */
-export default async function enrich(submittedDocument, remoteFile, triples) {
+export async function enrichSubmission(submittedDocument, fileUri, remoteDataObject, triples, documentUrl) {
   let enrichments = [];
 
   if (triples && triples.length) {
@@ -17,7 +17,7 @@ export default async function enrich(submittedDocument, remoteFile, triples) {
     enrichments = enrichments.concat(expandedSkos);
   }
 
-  const submissionUrlField = await addSubmissionUrl(submittedDocument, remoteFile, triples);
+  const submissionUrlField = await addSubmissionUrl(submittedDocument, fileUri, remoteDataObject, documentUrl);
   console.log(`Enrich submission with ${submissionUrlField.length} triples by adding the URL field.`);
   enrichments = enrichments.concat(submissionUrlField);
 
@@ -93,50 +93,33 @@ async function expandSkosTree(triples) {
  * Note: the remoteFile is already persisted in the store by the automatic-submission service.
  *       We just need to enrich the harvested triples dataset that will be written to a TTL file.
  */
-async function addSubmissionUrl(submittedDocument, remoteFile) {
-  let enrichments = [];
-  const result = await query(`
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-
-    SELECT ?harvestedHtmlFile ?url WHERE {
-      GRAPH ?g {
-        ?harvestedHtmlFile nie:dataSource ${sparqlEscapeUri(remoteFile)} .
-        ${sparqlEscapeUri(remoteFile)} nie:url ?url .
-      }
-    } LIMIT 1
-  `);
-
-  if (result.results.bindings.length) {
-    const harvestedFile = result.results.bindings[0]['harvestedHtmlFile'].value;
-    const url = result.results.bindings[0]['url'].value;
-    enrichments = translateRemoteUrlToSourceTriples(submittedDocument, remoteFile, url);
-    enrichments.push(
-      new Triple({
-        subject: harvestedFile,
-        predicate: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource',
-        object: remoteFile,
-        datatype: 'http://www.w3.org/2000/01/rdf-schema#Resource'
-      }));
-  }
-
+async function addSubmissionUrl(submittedDocument, fileUri, remoteDataObject, documentUrl) {
+  const enrichments = translateRemoteUrlToSourceTriples(submittedDocument, remoteDataObject, documentUrl);
+  enrichments.push(
+    new Triple({
+      subject: fileUri,
+      predicate: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource',
+      object: remoteDataObject,
+      datatype: 'http://www.w3.org/2000/01/rdf-schema#Resource'
+    }));
   return enrichments;
 }
 
-function translateRemoteUrlToSourceTriples(submittedDocument, remoteFile, url){
+function translateRemoteUrlToSourceTriples(submittedDocument, remoteDataObject, documentUrl) {
 const triples = [
       new Triple({
         subject: submittedDocument,
         predicate: 'http://purl.org/dc/terms/hasPart',
-        object: remoteFile,
+        object: remoteDataObject,
         datatype: 'http://www.w3.org/2000/01/rdf-schema#Resource'
       }),
       new Triple({
-        subject: remoteFile,
+        subject: remoteDataObject,
         predicate: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url',
-        object: url
+        object: documentUrl
       }),
       new Triple({
-        subject: remoteFile,
+        subject: remoteDataObject,
         predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
         object: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject',
         datatype: 'http://www.w3.org/2000/01/rdf-schema#Resource'

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -1,5 +1,5 @@
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { sparqlEscapeDateTime, sparqlEscapeUri } from 'mu';
+import { sparqlEscapeDateTime, sparqlEscapeUri, sparqlEscapeString, uuid } from 'mu';
 import * as env from '../constants.js';
 
 /**
@@ -8,12 +8,25 @@ import * as env from '../constants.js';
  * @param string taskUri URI of the task
  * @param string status URI of the new status
 */
-export async function updateTaskStatus(taskUri, status, errorUri) {
+export async function updateTaskStatus(taskUri, status, errorUri, importedFileUris) {
   const taskUriSparql = sparqlEscapeUri(taskUri);
   const nowSparql = sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
+
+  const resultContainerTriples = [];
+  if (importedFileUris)
+    for (const importedFileUri of importedFileUris) {
+      const resultContainerUuid = uuid();
+      resultContainerTriples.push(`
+        asj:${resultContainerUuid}
+          a nfo:DataContainer ;
+          mu:uuid ${sparqlEscapeString(resultContainerUuid)} ;
+          task:hasFile ${sparqlEscapeUri(importedFileUri)} .
+      `);
+    }
+
   const statusUpdateQuery = `
-    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task'])}
+    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
     DELETE {
       GRAPH ?g {
         ${taskUriSparql}
@@ -27,6 +40,8 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
           adms:status ${sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${sparqlEscapeUri(errorUri)} ;` : ''}
           dct:modified ${nowSparql} .
+
+        ${resultContainerTriples.join('\n')}
       }
     }
     WHERE {
@@ -41,8 +56,8 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
 }
 
 /**
- * Returns the inserted succesfully downloaded remote file URIs
- * from the delta message. An empty array if there are none.
+ * Returns the inserted succesfully downloaded remote file URI.
+ * An empty array if there are none.
  *
  * @param Object delta Message as received from the delta notifier
 */

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -13,17 +13,17 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
   const nowSparql = sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
 
-  const resultContainerTriples = [];
-  if (importedFileUris)
-    for (const importedFileUri of importedFileUris) {
-      const resultContainerUuid = uuid();
-      resultContainerTriples.push(`
-        asj:${resultContainerUuid}
-          a nfo:DataContainer ;
-          mu:uuid ${sparqlEscapeString(resultContainerUuid)} ;
-          task:hasFile ${sparqlEscapeUri(importedFileUri)} .
-      `);
-    }
+  let resultContainerTriples = '';
+  let resultContainerUuid = '';
+  if (importedFileUris) {
+    resultContainerUuid = uuid();
+    resultContainerTriples = `
+      asj:${resultContainerUuid}
+        a nfo:DataContainer ;
+        ${importedFileUris.map((uri) => `task:hasFile ${sparqlEscapeUri(uri)} ;`).join('\n')}
+        mu:uuid ${sparqlEscapeString(resultContainerUuid)} .
+    `;
+  }
 
   const statusUpdateQuery = `
     ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
@@ -39,9 +39,10 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
         ${taskUriSparql}
           adms:status ${sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${sparqlEscapeUri(errorUri)} ;` : ''}
+          ${resultContainerUuid ? `task:resultsContainer asj:${resultContainerUuid} ;` : ''}
           dct:modified ${nowSparql} .
 
-        ${resultContainerTriples.join('\n')}
+        ${resultContainerTriples}
       }
     }
     WHERE {

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -26,7 +26,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
   }
 
   const statusUpdateQuery = `
-    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
+    ${env.PREFIXES}
     DELETE {
       GRAPH ?g {
         ${taskUriSparql}
@@ -64,7 +64,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
 */
 export async function getRemoteDataObjectUris(taskUri) {
   const fileUriQuery = `
-    ${env.getPrefixes(['task'])}
+    ${env.PREFIXES}
     SELECT ?fileUri WHERE {
       ${sparqlEscapeUri(taskUri)} task:inputContainer ?inputContainer .
       ?inputContainer task:hasFile ?fileUri .
@@ -84,7 +84,7 @@ export async function getRemoteDataObjectUris(taskUri) {
 export async function getSubmissionInfo(remoteDataObject) {
   const remoteDataObjectSparql = sparqlEscapeUri(remoteDataObject);
   const infoQuery = `
-    ${env.getPrefixes(['nie', 'prov', 'dct'])}
+    ${env.PREFIXES}
     SELECT ?submission ?documentUrl ?fileUri ?submittedDocument
     WHERE {
       GRAPH ?g {

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -62,7 +62,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
  *
  * @param Object delta Message as received from the delta notifier
 */
-export async function getFileUris(taskUri) {
+export async function getRemoteDataObjectUris(taskUri) {
   const fileUriQuery = `
     ${env.getPrefixes(['task'])}
     SELECT ?fileUri WHERE {
@@ -81,15 +81,16 @@ export async function getFileUris(taskUri) {
  *
  * @param Array remoteFileUris URIs of the remote file objects
 */
-export async function getSubmissionInfo(fileUri) {
+export async function getSubmissionInfo(remoteDataObject) {
+  const remoteDataObjectSparql = sparqlEscapeUri(remoteDataObject);
   const infoQuery = `
     ${env.getPrefixes(['nie', 'prov', 'dct'])}
-    SELECT ?submission ?documentUrl ?remoteDataObject ?submittedDocument
+    SELECT ?submission ?documentUrl ?fileUri ?submittedDocument
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(fileUri)} nie:dataSource ?remoteDataObject .
+        ?fileUri nie:dataSource ${remoteDataObjectSparql} .
         ?submission
-          nie:hasPart ?remoteDataObject ;
+          nie:hasPart ${remoteDataObjectSparql} ;
           prov:atLocation ?documentUrl ;
           dct:subject ?submittedDocument .
       }
@@ -99,11 +100,11 @@ export async function getSubmissionInfo(fileUri) {
   const response = await query(infoQuery);
   let results = response.results.bindings;
   if (results.length > 0) results = results[0];
-  else throw new Error(`Could not find the information about the submission for file ${fileUri}`);
+  else throw new Error(`Could not find the information about the submission for file ${remoteDataObject}`);
   return {
     submission: results.submission.value,
     documentUrl: results.documentUrl.value,
     submittedDocument: results.submittedDocument.value,
-    remoteDataObject: results.remoteDataObject.value,
+    fileUri: results.fileUri.value,
   };
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -1,10 +1,6 @@
-import { sparqlEscapeUri } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-
-export const TASK_NOT_STARTED_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/not-started';
-export const TASK_ONGOING_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/importing';
-export const TASK_SUCCESS_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/ready-for-enrichment';
-export const TASK_FAILURE_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/failure';
+import { sparqlEscapeDateTime, sparqlEscapeUri } from 'mu';
+import * as env from '../constants.js';
 
 /**
  * Updates the state of the given task to the specified status
@@ -12,36 +8,55 @@ export const TASK_FAILURE_STATUS = 'http://lblod.data.gift/automatische-melding-
  * @param string taskUri URI of the task
  * @param string status URI of the new status
 */
-export async function updateTaskStatus(taskUri, status) {
-  const q = `
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-
+export async function updateTaskStatus(taskUri, status, errorUri) {
+  const taskUriSparql = sparqlEscapeUri(taskUri);
+  const nowSparql = sparqlEscapeDateTime((new Date()).toISOString());
+  const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
+  const statusUpdateQuery = `
+    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task'])}
     DELETE {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          dct:modified ?oldModified .
       }
     }
-
-    ;
-
     INSERT {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ${sparqlEscapeUri(status)} .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} a melding:AutomaticSubmissionTask .
+        ${taskUriSparql}
+          adms:status ${sparqlEscapeUri(status)} ;
+          ${hasError ? `task:error ${sparqlEscapeUri(errorUri)} ;` : ''}
+          dct:modified ${nowSparql} .
       }
     }
-
+    WHERE {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          dct:modified ?oldModified .
+      }
+    }
   `;
+  await update(statusUpdateQuery);
+}
 
-  await update(q);
+/**
+ * Returns the inserted succesfully downloaded remote file URIs
+ * from the delta message. An empty array if there are none.
+ *
+ * @param Object delta Message as received from the delta notifier
+*/
+export async function getFileUris(taskUri) {
+  const fileUriQuery = `
+    ${env.getPrefixes(['task'])}
+    SELECT ?fileUri WHERE {
+      ${sparqlEscapeUri(taskUri)} task:inputContainer ?inputContainer .
+      ?inputContainer task:hasFile ?fileUri .
+    }
+  `;
+  const response = await query(fileUriQuery);
+  const results = response.results?.bindings || [];
+  return results.map((res) => res.fileUri.value);
 }
 
 /**
@@ -50,42 +65,29 @@ export async function updateTaskStatus(taskUri, status) {
  *
  * @param Array remoteFileUris URIs of the remote file objects
 */
-export async function getTasks(remoteFileUris, status = TASK_NOT_STARTED_STATUS) {
-  const remoteDataObjectValues = `
-    VALUES ?remoteDataObject {
-      ${remoteFileUris.map(sparqlEscapeUri).join('\n')}
-    }
-  `;
-
-  const q = `
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-    PREFIX dct: <http://purl.org/dc/terms/>
-
-    SELECT ?submission ?documentUrl ?task ?remoteDataObject ?submittedDocument
+export async function getSubmissionInfo(fileUri) {
+  const infoQuery = `
+    ${env.getPrefixes(['nie', 'prov', 'dct'])}
+    SELECT ?submission ?documentUrl ?remoteDataObject ?submittedDocument
     WHERE {
       GRAPH ?g {
-        ?submission nie:hasPart ?remoteDataObject ;
-           prov:atLocation ?documentUrl .
-        ${remoteDataObjectValues}
-        ?task prov:generated ?submission ;
-           a melding:AutomaticSubmissionTask ;
-           adms:status ${sparqlEscapeUri(status)} .
-        ?submission dct:subject ?submittedDocument .
+        ${sparqlEscapeUri(fileUri)} nie:dataSource ?remoteDataObject .
+        ?submission
+          nie:hasPart ?remoteDataObject ;
+          prov:atLocation ?documentUrl ;
+          dct:subject ?submittedDocument .
       }
     }
   `;
 
-  const result = await query(q);
-  return result.results.bindings.map(binding => {
-    return {
-      task: binding['task'].value,
-      submission: binding['submission'].value,
-      documentUrl: binding['documentUrl'].value,
-      submittedDocument: binding['submittedDocument'].value,
-      remoteFile: binding['remoteDataObject'].value
-    };
-  });
+  const response = await query(infoQuery);
+  let results = response.results.bindings;
+  if (results.length > 0) results = results[0];
+  else throw new Error(`Could not find the information about the submission for file ${fileUri}`);
+  return {
+    submission: results.submission.value,
+    documentUrl: results.documentUrl.value,
+    submittedDocument: results.submittedDocument.value,
+    remoteDataObject: results.remoteDataObject.value,
+  };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,41 @@
+import {  updateSudo as update } from '@lblod/mu-auth-sudo';
+import { uuid, sparqlEscapeString, sparqlEscapeDateTime, sparqlEscapeUri } from 'mu';
+import * as env from '../constants.js';
+
+export async function saveError({message, detail, reference}) {
+  if (!message)
+    throw 'Error needs a message describing what went wrong.';
+  const id = uuid();
+  const uri = `http://data.lblod.info/errors/${id}`;
+  const q = `
+    PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct:  <http://purl.org/dc/terms/>
+    PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+    INSERT DATA {
+      GRAPH <http://mu.semte.ch/graphs/error> {
+        ${sparqlEscapeUri(uri)}
+          a oslc:Error ;
+          mu:uuid ${sparqlEscapeString(id)} ;
+          dct:subject ${sparqlEscapeString('Automatic Submission Service')} ;
+          oslc:message ${sparqlEscapeString(message)} ;
+          dct:created ${sparqlEscapeDateTime(new Date().toISOString())} ;
+          ${reference ? `dct:references ${sparqlEscapeUri(reference)} ;` : ''}
+          ${detail ? `oslc:largePreview ${sparqlEscapeString(detail)} ;` : ''}
+          dct:creator ${sparqlEscapeUri(env.CREATOR)} .
+      }
+    }
+   `;
+  try {
+    await update(q);
+    return uri;
+  }
+  catch (e) {
+    console.warn(`[WARN] Something went wrong while trying to store an error.\nMessage: ${e}\nQuery: ${q}`);
+  }
+}
+
 export function isCentraalBestuurVanEredienstDocument(submittedDocument, triples) {
   const list = [
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349",


### PR DESCRIPTION
This service now starts from a scheduled task with import operation. It reads the file URI of the input container of the task instead of looking for the task and related document URI's. Some functions have been removed or rewritten because of this.
There is also a different error handling mechanism and all constants have been moved to a separate file.

To do for later: when this service unexpectedly shuts down, it does not restart previous tasks yet, which was a functionality from before. We probably want to move this functionality to the job-controller anyway, so that this does not have to be implemented in all the services of the submission flow.