### PR TITLE
Reverting to previous file linking

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,8 +36,9 @@ app.post('/delta', async function(req, res, next) {
         const remoteDataObjects = await getRemoteDataObjectUris(taskUri);
         const importedFileUris = [];
         for (const remoteDataObject of remoteDataObjects) {
-          const importedFileUri = await importSubmission(remoteDataObject);
-          importedFileUris.push(importedFileUri);
+          const { logicalUri, physicalUri } = await importSubmission(remoteDataObject);
+          //Give logical file uri and not physical, because this is for the tasks and the dashboard
+          importedFileUris.push(logicalUri);
         }
         await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS, undefined, importedFileUris);
       }
@@ -79,9 +80,9 @@ async function importSubmission(remoteDataObject) {
   }
 
   const ttl = rdfaExtractor.ttl();
-  const uri = await writeTtlFile(ttl, submittedDocument, remoteDataObject);
-  console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteDataObject}> to <${uri}>`);
-  return uri;
+  const { logicalUri, physicalUri } = await writeTtlFile(ttl, submittedDocument, remoteDataObject);
+  console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteDataObject}> to <${logicalUri}>`);
+  return { logicalUri, physicalUri };
 }
 
 function calculateAttachmentsToDownlad(triples, submittedDocument){

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -45,6 +45,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
             a nfo:FileDataObject;
             nie:dataSource asj:${logicalId} ;
             mu:uuid ${sparqlEscapeString(physicalId)};
+            dct:type <http://data.lblod.gift/concepts/harvested-data> ;
             nfo:fileName ${sparqlEscapeString(filename)} ;
             dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
             dct:created ${nowSparql} ;

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -65,7 +65,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
             nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
             dbpedia:fileExtension "ttl" .
             
-          ${sparqlEscapeUri(submittedDocument)} dct:source asj:${logicalId} .
+          ${sparqlEscapeUri(submittedDocument)} dct:source ${sparqlEscapeUri(physicalUri)} .
         }
       }
       WHERE {
@@ -78,5 +78,5 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
     console.log(`Failed to write TTL resource <${physicalUri}> to triplestore.`);
     throw e;
   }
-  return logicalUri;
+  return { physicalUri, logicalUri };
 }


### PR DESCRIPTION
In a previous version, the imported file was linked to the Submitted Document by means of a physical file. Due to the introduction of the `cogs:Job` model and the interoperability with the job-controller and the dashboard, the Submitted Document was linked to a logical file, just like the task for this service.

We are now rolling back that decision because of backwards compatibility problems, but while keeping the interoperability with the dashboard and the job-controller.