### PR TITLE
Only insert in one graph

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,8 +36,8 @@ app.post('/delta', async function(req, res, next) {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         const remoteDataObjects = await getRemoteDataObjectUris(taskUri);
         const importedFileUris = [];
-        const reqState = { req, taskUri, remoteDataObject };
         for (const remoteDataObject of remoteDataObjects) {
+          const reqState = { req, taskUri, remoteDataObject };
           const { logicalUri, physicalUri } = await importSubmission(remoteDataObject, reqState);
           //Give logical file uri and not physical, because this is for the tasks and the dashboard
           importedFileUris.push(logicalUri);

--- a/app.js
+++ b/app.js
@@ -78,14 +78,14 @@ async function importSubmission(remoteDataObject, reqState) {
     console.log(`Found attachments: ${attachmentUrls.join('\n')}`);
     for(const attachmentUrl of attachmentUrls){
       //Note: there is no clear message when attachment download failed.
-      const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl);
+      const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl, reqState);
       const enrichments = await enrichWithAttachmentInfo(submittedDocument, remoteDataObject, attachmentUrl);
       rdfaExtractor.add(enrichments);
     }
   }
 
   const ttl = rdfaExtractor.ttl();
-  const { logicalUri, physicalUri } = await writeTtlFile(ttl, submittedDocument, remoteDataObject);
+  const { logicalUri, physicalUri } = await writeTtlFile(ttl, submittedDocument, remoteDataObject, reqState);
   console.log(`Successfully extracted data for submission <${submission}> from remote file <${remoteDataObject}> to <${logicalUri}>`);
   return { logicalUri, physicalUri };
 }

--- a/app.js
+++ b/app.js
@@ -67,7 +67,6 @@ app.post('/delta', async function(req, res, next) {
 
 async function importSubmission(remoteDataObject, reqState) {
   const { submission, documentUrl, submittedDocument, fileUri } = await getSubmissionInfo(remoteDataObject, reqState.submissionGraph);
-  //TODO add reqState as arg to functions that need it
   const html = await loadFileData(fileUri);
   const rdfaExtractor = new RdfaExtractor(html, documentUrl);
   const triples = rdfaExtractor.rdfa();

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+import * as env from 'env-var';
+
+export const GRAPH_TEMPLATE = env.get('GRAPH_TEMPLATE')
+  .example('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .default('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(`The GRAPH_TEMPLATE environment variable ${GRAPH_TEMPLATE} does not contain a ~ORGANIZATION_ID~.`);
+})();

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -16,25 +16,22 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
   // If by then, download-url hasn't finished successfuly its task, it won't be able to do so anymore
   //
   // Note: probably some clean up background job might be needed. Needs perhaps a bit of better thinking
-  const newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, submission);
+  const newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, submission, reqState);
 
   try {
     const queryString = `
       ${PREFIXES}
       INSERT {
         GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
-         ${sparqlEscapeUri(remoteDataUri)} a nfo:RemoteDataObject, nfo:FileDataObject;
-           rpioHttp:requestHeader <http://data.lblod.info/request-headers/29b14d06-e584-45d6-828a-ce1f0c018a8e>;
-           mu:uuid ${sparqlEscapeString(remoteDataId)};
-           nie:url ${sparqlEscapeUri(remoteFile)};
-           dct:creator <http://lblod.data.gift/services/import-submission-service>;
-           adms:status <http://lblod.data.gift/file-download-statuses/ready-to-be-cached>;
-           dct:created ${sparqlEscapeDateTime(timestamp)};
-           dct:modified ${sparqlEscapeDateTime(timestamp)}.
-
-        }
-        GRAPH ?submissionGraph {
-           ${sparqlEscapeUri(submission)} nie:hasPart ${sparqlEscapeUri(remoteDataUri)}.
+          ${sparqlEscapeUri(remoteDataUri)} a nfo:RemoteDataObject, nfo:FileDataObject;
+            rpioHttp:requestHeader <http://data.lblod.info/request-headers/29b14d06-e584-45d6-828a-ce1f0c018a8e>;
+            mu:uuid ${sparqlEscapeString(remoteDataId)};
+            nie:url ${sparqlEscapeUri(remoteFile)};
+            dct:creator <http://lblod.data.gift/services/import-submission-service>;
+            adms:status <http://lblod.data.gift/file-download-statuses/ready-to-be-cached>;
+            dct:created ${sparqlEscapeDateTime(timestamp)};
+            dct:modified ${sparqlEscapeDateTime(timestamp)}.
+          ${sparqlEscapeUri(submission)} nie:hasPart ${sparqlEscapeUri(remoteDataUri)}.
         }
       }
       WHERE {
@@ -42,6 +39,7 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
           ${sparqlEscapeUri(submission)} nie:hasPart ?remoteDataObject.
           ?remoteDataObject a ?type.
         }
+      }
     `;
 
       await update(queryString);

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -3,7 +3,7 @@ import { sparqlEscapeDateTime, sparqlEscapeString, uuid, sparqlEscapeUri } from 
 import { PREFIXES } from '../constants';
 import { attachClonedAuthenticationConfiguraton, cleanCredentials } from './credential-helpers';
 
-export async function scheduleDownloadAttachment(submission, remoteFile){
+export async function scheduleDownloadAttachment(submission, remoteFile, reqState){
   const remoteDataId = uuid();
   const remoteDataUri = `http://data.lblod.info/id/remote-data-objects/${remoteDataId}`;
   const timestamp = new Date();
@@ -22,7 +22,7 @@ export async function scheduleDownloadAttachment(submission, remoteFile){
     const queryString = `
       ${PREFIXES}
       INSERT {
-        GRAPH ?filesGraph {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
          ${sparqlEscapeUri(remoteDataUri)} a nfo:RemoteDataObject, nfo:FileDataObject;
            rpioHttp:requestHeader <http://data.lblod.info/request-headers/29b14d06-e584-45d6-828a-ce1f0c018a8e>;
            mu:uuid ${sparqlEscapeString(remoteDataId)};
@@ -38,13 +38,10 @@ export async function scheduleDownloadAttachment(submission, remoteFile){
         }
       }
       WHERE {
-        GRAPH ?submissionGraph {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submission)} nie:hasPart ?remoteDataObject.
-        }
-        GRAPH ?filesGraph {
           ?remoteDataObject a ?type.
         }
-      }
     `;
 
       await update(queryString);

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -32,16 +32,14 @@ export async function cleanCredentials(authenticationConfigurationUri){
   await update(cleanQuery);
 }
 
-export async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submissionUri){
+export async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submissionUri, reqState) {
   const getInfoQuery = `
     ${PREFIXES}
-    SELECT DISTINCT ?graph ?remoteObjectGraph ?secType ?authenticationConfiguration WHERE {
-     GRAPH ?graph {
+    SELECT DISTINCT ?graph ?secType ?authenticationConfiguration WHERE {
+     GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
        ${sparqlEscapeUri(submissionUri)} dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration.
        ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?secType .
        ${sparqlEscapeUri(submissionUri)} nie:hasPart ?remoteDataObject.
-     }
-     GRAPH ?remoteObjectGraph {
        ?remoteDataObject a ?type .
      }
     }
@@ -61,11 +59,8 @@ export async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri
     cloneQuery = `
       ${PREFIXES}
       INSERT {
-        GRAPH ${sparqlEscapeUri(authData.remoteObjectGraph)} {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConf)} .
-        }
-
-        GRAPH ${sparqlEscapeUri(authData.graph)} {
           ${sparqlEscapeUri(newAuthConf)} dgftSec:secrets ${sparqlEscapeUri(newCreds)} .
           ${sparqlEscapeUri(newCreds)} meb:username ?user ;
             muAccount:password ?pass .
@@ -75,24 +70,22 @@ export async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri
         }
       }
       WHERE {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+          ?srcConfg ?srcConfP ?srcConfO.
 
-       ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
-       ?srcSecrets  meb:username ?user ;
-         muAccount:password ?pass .
-     }
-   `;
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+          ?srcSecrets  meb:username ?user ;
+            muAccount:password ?pass .
+        }
+      }`;
   }
   else if(authData.secType == OAUTH2){
     cloneQuery = `
       ${PREFIXES}
       INSERT {
-        GRAPH ${sparqlEscapeUri(authData.remoteObjectGraph)} {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)}
           ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConf)} .
-        }
-
-        GRAPH ${sparqlEscapeUri(authData.graph)} {
           ${sparqlEscapeUri(newAuthConf)} dgftSec:secrets ${sparqlEscapeUri(newCreds)} .
           ${sparqlEscapeUri(newCreds)} dgftOauth:clientId ?clientId ;
             dgftOauth:clientSecret ?clientSecret .
@@ -102,14 +95,15 @@ export async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri
         }
       }
       WHERE {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+          ?srcConfg ?srcConfP ?srcConfO.
 
-       ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
-       ?srcSecrets  dgftOauth:clientId ?clientId ;
-         dgftOauth:clientSecret ?clientSecret .
-     }
-   `;
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+          ?srcSecrets  dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+        }
+      }`;
   }
   else {
     throw `Unsupported Security type ${authData.secType}`;

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -67,7 +67,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile, reqSt
             nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
             dbpedia:fileExtension "ttl" .
             
-          ${sparqlEscapeUri(submittedDocument)} dct:source asj:${logicalId} .
+          ${sparqlEscapeUri(submittedDocument)} dct:source ${sparqlEscapeUri(physicalUri)} .
         }
       }
       WHERE {

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -67,7 +67,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile, reqSt
             nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
             dbpedia:fileExtension "ttl" .
             
-          ${sparqlEscapeUri(submittedDocument)} dct:source ${sparqlEscapeUri(physicalUri)} .
+          ${sparqlEscapeUri(submittedDocument)} dct:source asj:${logicalId} .
         }
       }
       WHERE {

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -17,7 +17,7 @@ export async function loadFileData(fileUri){
  * @param string submittedDocument URI of the submittedDocument to relate the new TTL file to
  * @param string remoteFile URI of the remote file to relate the new TTL file to
 */
-export async function writeTtlFile(content, submittedDocument, remoteFile) {
+export async function writeTtlFile(content, submittedDocument, remoteFile, reqState) {
   const physicalId = uuid();
   const logicalId = uuid();
   const filename = `${physicalId}.ttl`;
@@ -40,7 +40,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
     await update(`
       ${env.PREFIXES}
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(physicalUri)}
             a nfo:FileDataObject;
             nie:dataSource asj:${logicalId} ;
@@ -71,7 +71,7 @@ export async function writeTtlFile(content, submittedDocument, remoteFile) {
         }
       }
       WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(remoteFile)} a nfo:FileDataObject .
           ?localFile nie:dataSource ${sparqlEscapeUri(remoteFile)}.
         }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -8,7 +8,7 @@ import * as env from '../constants.js';
  * @param string taskUri URI of the task
  * @param string status URI of the new status
 */
-export async function updateTaskStatus(taskUri, status, errorUri, importedFileUris) {
+export async function updateTaskStatus(taskUri, status, errorUri, importedFileUris, graph) {
   const taskUriSparql = sparqlEscapeUri(taskUri);
   const nowSparql = sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
@@ -28,14 +28,14 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
   const statusUpdateQuery = `
     ${env.PREFIXES}
     DELETE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
       }
     }
     INSERT {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ${sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${sparqlEscapeUri(errorUri)} ;` : ''}
@@ -46,7 +46,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
       }
     }
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
@@ -62,12 +62,14 @@ export async function updateTaskStatus(taskUri, status, errorUri, importedFileUr
  *
  * @param Object delta Message as received from the delta notifier
 */
-export async function getRemoteDataObjectUris(taskUri) {
+export async function getRemoteDataObjectUris(taskUri, graph) {
   const fileUriQuery = `
     ${env.PREFIXES}
     SELECT ?fileUri WHERE {
-      ${sparqlEscapeUri(taskUri)} task:inputContainer ?inputContainer .
-      ?inputContainer task:hasFile ?fileUri .
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ${sparqlEscapeUri(taskUri)} task:inputContainer ?inputContainer .
+        ?inputContainer task:hasFile ?fileUri .
+      }
     }
   `;
   const response = await query(fileUriQuery);
@@ -81,21 +83,19 @@ export async function getRemoteDataObjectUris(taskUri) {
  *
  * @param Array remoteFileUris URIs of the remote file objects
 */
-export async function getSubmissionInfo(remoteDataObject) {
+export async function getSubmissionInfo(remoteDataObject, graph) {
   const remoteDataObjectSparql = sparqlEscapeUri(remoteDataObject);
   const infoQuery = `
     ${env.PREFIXES}
-    SELECT ?submission ?documentUrl ?fileUri ?submittedDocument ?organisationId
+    SELECT ?submission ?documentUrl ?fileUri ?submittedDocument
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ?fileUri nie:dataSource ${remoteDataObjectSparql} .
         ?submission
-          pav:createdBy ?bestuurseenheid ;
           nie:hasPart ${remoteDataObjectSparql} ;
           prov:atLocation ?documentUrl ;
           dct:subject ?submittedDocument .
       }
-      ?bestuurseenheid mu:uuid ?organisationId .
     }
   `;
 
@@ -108,6 +108,19 @@ export async function getSubmissionInfo(remoteDataObject) {
     documentUrl: results.documentUrl.value,
     submittedDocument: results.submittedDocument.value,
     fileUri: results.fileUri.value,
-    organisationId: results.organisationId.value,
   };
+}
+
+export async function getOrganisationIdFromTask(taskUri) {
+  const response = await query(`
+    ${env.PREFIXES}
+    SELECT DISTINCT ?organisationId WHERE {
+      ${sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+      ?job prov:generated ?submission .
+      ?submission pav:createdBy ?bestuurseenheid .
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }
+    LIMIT 1
+  `);
+  return response?.results?.bindings[0]?.organisationId?.value;
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -85,14 +85,16 @@ export async function getSubmissionInfo(remoteDataObject) {
   const remoteDataObjectSparql = sparqlEscapeUri(remoteDataObject);
   const infoQuery = `
     ${env.PREFIXES}
-    SELECT ?submission ?documentUrl ?fileUri ?submittedDocument
+    SELECT ?submission ?documentUrl ?fileUri ?submittedDocument ?organisationId
     WHERE {
       GRAPH ?g {
         ?fileUri nie:dataSource ${remoteDataObjectSparql} .
         ?submission
+          pav:createdBy ?bestuurseenheid ;
           nie:hasPart ${remoteDataObjectSparql} ;
           prov:atLocation ?documentUrl ;
           dct:subject ?submittedDocument .
+        ?bestuurseenheid mu:uuid ?organisationId .
       }
     }
   `;
@@ -106,5 +108,6 @@ export async function getSubmissionInfo(remoteDataObject) {
     documentUrl: results.documentUrl.value,
     submittedDocument: results.submittedDocument.value,
     fileUri: results.fileUri.value,
+    organisationId: results.organisationId.value,
   };
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -94,8 +94,8 @@ export async function getSubmissionInfo(remoteDataObject) {
           nie:hasPart ${remoteDataObjectSparql} ;
           prov:atLocation ?documentUrl ;
           dct:subject ?submittedDocument .
-        ?bestuurseenheid mu:uuid ?organisationId .
       }
+      ?bestuurseenheid mu:uuid ?organisationId .
     }
   `;
 

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "@lblod/marawa": "^0.7.1",
     "@lblod/mu-auth-sudo": "^0.2.0",
     "body-parser": "1.19.0",
+    "env-var": "^7.3.0",
     "fs-extra": "8.1.0",
     "jsdom": "^11.6.2",
     "lodash": "^4.17.11",
     "uuid": "^8.3.2"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
In order to improve data security, the services in the automatic submission flow should only insert data in one specific controlled graph.

This fixes issues related to data spreading in graphs that should not contain that data. More specific for the vendor-data-distribution-service.

This PR includes a configuration file where the graph template is loaded from environment variables, but with sensible defaults so that nothing special should be done in most cases. The code is adapted to always compute the graph from the template in combination with the organisation ID before inserting into the triplestore.