### PR TITLE
Feature/custom code path extract file name vandenbroele attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ ___
 
 For a full list of properties of a submitted resource, we refer to the [automatic submission documentation](https://lblod.github.io/pages-vendors/#/docs/submission-annotations).
 
+## Environment variables
+| Name | Description | Default |
+|------|-------------|---------|
+| `VANDENBROELE_URI` | URI of the Vandenbroele vendor used to detect submissions from this vendor | `http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e` |
+| `APPLY_VANDENBROELE_FILENAME_WORKAROUND` | When `true`, enables a workaround that tries to extract a suggested filename from the submission HTML for Vandenbroele submissions. The filename is attached as `ext:suggestedFilename` to the scheduled remote data object. | `false` |
+
 ## Related services
 The following services are also involved in the automatic processing of a submission:
 * [automatic-submission-service](https://github.com/lblod/automatic-submission-service)

--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ async function importSubmission(remoteDataObject, reqState) {
     console.log(`Found attachments: ${attachmentUrls.join('\n')}`);
     for(const attachmentUrl of attachmentUrls){
       //Note: there is no clear message when attachment download failed.
-      const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl, reqState);
+      const remoteDataObject = await scheduleDownloadAttachment(submission, attachmentUrl, reqState, html);
       const enrichments = await enrichWithAttachmentInfo(submittedDocument, remoteDataObject, attachmentUrl);
       rdfaExtractor.add(enrichments);
     }

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -5,6 +5,7 @@ import { PREFIXES } from '../constants';
 import { attachClonedAuthenticationConfiguraton, cleanCredentials } from './credential-helpers';
 
 const VANDENBROELE_URI = process.env.VANDENBROELE_URI || 'http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e';
+const APPLY_VANDENBROELE_FILENAME_WORKAROUND = (process.env.APPLY_VANDENBROELE_FILENAME_WORKAROUND || 'false') === 'true';
 
 async function isProvidedByVandenbroele(submission) {
   const result = await query(`
@@ -57,7 +58,7 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
     let potentialFilenameTriple = '';
 
     // Note: TODO this is a temporary workaround until VDB sets proper filename.
-    const isVandenbroeleSubmission = await isProvidedByVandenbroele(submission);
+    const isVandenbroeleSubmission = APPLY_VANDENBROELE_FILENAME_WORKAROUND && await isProvidedByVandenbroele(submission);
     if (isVandenbroeleSubmission) {
       const potentialFilename = guesstimateVandenbroeleFilename(html, remoteFile);
       if (potentialFilename) {

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -1,9 +1,42 @@
-import { updateSudo as update } from '@lblod/mu-auth-sudo';
+import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeDateTime, sparqlEscapeString, uuid, sparqlEscapeUri } from 'mu';
+import { JSDOM } from 'jsdom';
 import { PREFIXES } from '../constants';
 import { attachClonedAuthenticationConfiguraton, cleanCredentials } from './credential-helpers';
 
-export async function scheduleDownloadAttachment(submission, remoteFile, reqState){
+const VANDENBROELE_URI = process.env.VANDENBROELE_URI || 'http://data.lblod.info/vendors/lblod-as-vendor/993b42f4-bd97-44ab-9719-667146a78f86';
+
+async function isProvidedByVandenbroele(submission) {
+  const result = await query(`
+    ${PREFIXES}
+    ASK {
+      ${sparqlEscapeUri(submission)} pav:providedBy ${sparqlEscapeUri(VANDENBROELE_URI)}.
+    }
+  `);
+  return result.boolean;
+}
+
+function extractPotentialFileName(html, remoteFile) {
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+  const anchors = document.querySelectorAll(`[href="${remoteFile}"]`);
+
+  for (const anchor of anchors) {
+    if (anchor.children.length > 0) continue;
+
+    const text = anchor.textContent.trim().replace(/ /g, '_');
+    if (!text) continue;
+
+    const parts = text.split('.');
+    if (parts.length === 2 && parts[0].length > 0 && parts[1].length > 0) {
+      return text;
+    }
+  }
+
+  return '';
+}
+
+export async function scheduleDownloadAttachment(submission, remoteFile, reqState, html){
   const remoteDataId = uuid();
   const remoteDataUri = `http://data.lblod.info/id/remote-data-objects/${remoteDataId}`;
   const timestamp = new Date();
@@ -19,6 +52,16 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
   const newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, submission, reqState);
 
   try {
+    let potentialFileName = '';
+
+    const isVandenbroele = await isProvidedByVandenbroele(submission);
+    if (isVandenbroele) {
+      const potentialFileName = extractPotentialFileName(html, remoteFile);
+      if (potentialFileName) {
+        potentialFileName = `ext:potentialFileName ${sparqlEscapeString(potentialFileName)};`;
+      }
+    }
+
     const queryString = `
       ${PREFIXES}
       INSERT {
@@ -29,8 +72,10 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
             nie:url ${sparqlEscapeUri(remoteFile)};
             dct:creator <http://lblod.data.gift/services/import-submission-service>;
             adms:status <http://lblod.data.gift/file-download-statuses/ready-to-be-cached>;
+            ${potentialFileName}
             dct:created ${sparqlEscapeDateTime(timestamp)};
             dct:modified ${sparqlEscapeDateTime(timestamp)}.
+
           ${sparqlEscapeUri(submission)} nie:hasPart ${sparqlEscapeUri(remoteDataUri)}.
         }
       }

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -19,7 +19,7 @@ async function isProvidedByVandenbroele(submission) {
 function extractPotentialFileName(html, remoteFile) {
   const dom = new JSDOM(html);
   const document = dom.window.document;
-  const anchors = document.querySelectorAll(`[href="${remoteFile}"]`);
+  const anchors = document.querySelectorAll(`a[href="${remoteFile}"]`);
 
   for (const anchor of anchors) {
     if (anchor.children.length > 0) continue;

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -56,6 +56,7 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
   try {
     let potentialFileName = '';
 
+    // Note: TODO this is a temporary workaround until VDB sets proper filename.
     const isVandenbroeleSubmission = await isProvidedByVandenbroele(submission);
     if (isVandenbroeleSubmission) {
       const potentialFileName = guesstimateVandenbroeleFilename(html, remoteFile);

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -27,7 +27,7 @@ function guesstimateVandenbroeleFilename(html, remoteFile) {
   for (const anchor of anchors) {
     if (anchor.children.length > 0) continue;
 
-    const text = anchor.textContent.trim().replace(/ /g, '_');
+    const text = anchor.textContent.trim();
     if (!text) continue;
 
     const parts = text.split('.');

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -54,14 +54,14 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
   const newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, submission, reqState);
 
   try {
-    let potentialFileName = '';
+    let potentialFilenameTriple = '';
 
     // Note: TODO this is a temporary workaround until VDB sets proper filename.
     const isVandenbroeleSubmission = await isProvidedByVandenbroele(submission);
     if (isVandenbroeleSubmission) {
-      const potentialFileName = guesstimateVandenbroeleFilename(html, remoteFile);
-      if (potentialFileName) {
-        potentialFileName = `ext:suggestedFileName ${sparqlEscapeString(potentialFileName)};`;
+      const potentialFilename = guesstimateVandenbroeleFilename(html, remoteFile);
+      if (potentialFilename) {
+        potentialFilenameTriple = `ext:suggestedFilename ${sparqlEscapeString(potentialFilename)};`;
       }
     }
 
@@ -75,7 +75,7 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
             nie:url ${sparqlEscapeUri(remoteFile)};
             dct:creator <http://lblod.data.gift/services/import-submission-service>;
             adms:status <http://lblod.data.gift/file-download-statuses/ready-to-be-cached>;
-            ${potentialFileName}
+            ${potentialFilenameTriple}
             dct:created ${sparqlEscapeDateTime(timestamp)};
             dct:modified ${sparqlEscapeDateTime(timestamp)}.
 

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -16,7 +16,9 @@ async function isProvidedByVandenbroele(submission) {
   return result.boolean;
 }
 
-function extractPotentialFileName(html, remoteFile) {
+function guesstimateVandenbroeleFilename(html, remoteFile) {
+  // File name is expected to be buried in e.g.
+  // <a property="a:property" href="remoteFileUrl" target="_blank">Advies.pdf</a>
   const dom = new JSDOM(html);
   const document = dom.window.document;
   const anchors = document.querySelectorAll(`a[href="${remoteFile}"]`);
@@ -54,11 +56,11 @@ export async function scheduleDownloadAttachment(submission, remoteFile, reqStat
   try {
     let potentialFileName = '';
 
-    const isVandenbroele = await isProvidedByVandenbroele(submission);
-    if (isVandenbroele) {
-      const potentialFileName = extractPotentialFileName(html, remoteFile);
+    const isVandenbroeleSubmission = await isProvidedByVandenbroele(submission);
+    if (isVandenbroeleSubmission) {
+      const potentialFileName = guesstimateVandenbroeleFilename(html, remoteFile);
       if (potentialFileName) {
-        potentialFileName = `ext:potentialFileName ${sparqlEscapeString(potentialFileName)};`;
+        potentialFileName = `ext:suggestedFileName ${sparqlEscapeString(potentialFileName)};`;
       }
     }
 

--- a/lib/attachment-helpers.js
+++ b/lib/attachment-helpers.js
@@ -4,7 +4,7 @@ import { JSDOM } from 'jsdom';
 import { PREFIXES } from '../constants';
 import { attachClonedAuthenticationConfiguraton, cleanCredentials } from './credential-helpers';
 
-const VANDENBROELE_URI = process.env.VANDENBROELE_URI || 'http://data.lblod.info/vendors/lblod-as-vendor/993b42f4-bd97-44ab-9719-667146a78f86';
+const VANDENBROELE_URI = process.env.VANDENBROELE_URI || 'http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e';
 
 async function isProvidedByVandenbroele(submission) {
   const result = await query(`


### PR DESCRIPTION
We added an extra ad hoc heuristic to extract filenames and attach them as a suggestion to the remote data object. This gives the download-url service an additional way to figure out the filename.

This is needed because the business context is really expecting it. It is brittle and should be considered a temporary workaround until vandenbroele is informed and updates the situation.

See also: [DL-7047] and https://github.com/lblod/download-url-service/pull/22